### PR TITLE
Reposition email fields and rename persona principal

### DIFF
--- a/src/pages/BusinessQuoteForm.tsx
+++ b/src/pages/BusinessQuoteForm.tsx
@@ -259,7 +259,19 @@ const BusinessQuoteForm = ({ quoteType = 'corporativos' }) => {
                   required
                   error={errors.nombreContacto}
                 />
-                
+
+                <FormInput
+                  label="Correo Electrónico"
+                  name="correoElectronico"
+                  type="email"
+                  value={formState.correoElectronico}
+                  onChange={handleInputChange}
+                  required
+                  error={errors.correoElectronico}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <FormInput
                   label="NIT"
                   name="nit"
@@ -269,9 +281,7 @@ const BusinessQuoteForm = ({ quoteType = 'corporativos' }) => {
                   error={errors.nit}
                   placeholder="900123456-1"
                 />
-              </div>
-              
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
                 <FormInput
                   label="Dirección"
                   name="direccion"
@@ -280,7 +290,9 @@ const BusinessQuoteForm = ({ quoteType = 'corporativos' }) => {
                   required
                   error={errors.direccion}
                 />
-                
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <PhoneInput
                   label="Teléfono"
                   name="telefono"
@@ -289,26 +301,16 @@ const BusinessQuoteForm = ({ quoteType = 'corporativos' }) => {
                   required
                   error={errors.telefono}
                 />
+
+                <FormInput
+                  label="Razón Social"
+                  name="razonSocial"
+                  value={formState.razonSocial}
+                  onChange={handleInputChange}
+                  required
+                  error={errors.razonSocial}
+                />
               </div>
-              
-              <FormInput
-                label="Correo Electrónico"
-                name="correoElectronico"
-                type="email"
-                value={formState.correoElectronico}
-                onChange={handleInputChange}
-                required
-                error={errors.correoElectronico}
-              />
-              
-              <FormInput
-                label="Razón Social"
-                name="razonSocial"
-                value={formState.razonSocial}
-                onChange={handleInputChange}
-                required
-                error={errors.razonSocial}
-              />
               
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <FormInput

--- a/src/pages/HealthQuoteForm.tsx
+++ b/src/pages/HealthQuoteForm.tsx
@@ -39,7 +39,7 @@ const healthData = {
 const HealthQuoteForm = () => {
   const navigate = useNavigate();
   const [formState, setFormState] = useState({
-    // Información de la póliza de salud - Persona principal
+    // Información de la póliza de salud - tomador
     nombreCompleto: '',
     tipoDocumento: '',
     numeroDocumento: '',
@@ -207,7 +207,7 @@ const HealthQuoteForm = () => {
   const validateForm = () => {
     const newErrors = {};
     
-    // Validar información de la póliza de salud - Persona principal
+    // Validar información de la póliza de salud - tomador
     if (!formState.nombreCompleto) newErrors.nombreCompleto = 'El campo Nombre completo es requerido';
     if (!formState.tipoDocumento) newErrors.tipoDocumento = 'El campo Tipo de documento es requerido';
     if (!formState.numeroDocumento) newErrors.numeroDocumento = 'El campo Número documento es requerido';
@@ -322,9 +322,9 @@ const HealthQuoteForm = () => {
       
       <div className="bg-white rounded-lg shadow-md border border-gray-200 overflow-hidden mb-8">
         <div className="p-6 md:p-8">
-          {/* Póliza de salud - Persona principal */}
+          {/* Póliza de salud - tomador */}
           <FormSection 
-            title="COTIZAR PÓLIZA DE SALUD - PERSONA PRINCIPAL" 
+            title="COTIZAR PÓLIZA DE SALUD - TOMADOR" 
             icon={<User size={24} className="text-green-500" />}
           >
             <div className="space-y-6">
@@ -337,7 +337,16 @@ const HealthQuoteForm = () => {
                   required
                   error={errors.nombreCompleto}
                 />
-                
+
+                <FormInput
+                  label="Su correo electrónico"
+                  name="email"
+                  type="email"
+                  value={formState.email}
+                  onChange={handleInputChange}
+                  error={errors.email}
+                />
+
                 <FormSelect
                   label="Tipo de documento"
                   name="tipoDocumento"
@@ -347,7 +356,9 @@ const HealthQuoteForm = () => {
                   required
                   error={errors.tipoDocumento}
                 />
-                
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <FormInput
                   label="Número documento"
                   name="numeroDocumento"
@@ -356,9 +367,7 @@ const HealthQuoteForm = () => {
                   required
                   error={errors.numeroDocumento}
                 />
-              </div>
-              
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
                 <FormInput
                   label="Edad en años"
                   name="edad"
@@ -368,7 +377,7 @@ const HealthQuoteForm = () => {
                   required
                   error={errors.edad}
                 />
-                
+
                 <PhoneInput
                   label="Celular"
                   name="celular"
@@ -506,19 +515,11 @@ const HealthQuoteForm = () => {
             </FormSection>
           ))}
 
-          {/* Email adicional */}
-          <FormSection 
-            title="INFORMACIÓN ADICIONAL" 
+          {/* Información adicional */}
+          <FormSection
+            title="INFORMACIÓN ADICIONAL"
           >
             <div className="space-y-6">
-              <FormInput
-                label="Su correo electrónico"
-                name="email"
-                type="email"
-                value={formState.email}
-                onChange={handleInputChange}
-                error={errors.email}
-              />
               
               <div className="bg-green-50 p-6 rounded-lg border border-green-200">
                 <div className="flex items-start">

--- a/src/pages/HomeQuoteForm.tsx
+++ b/src/pages/HomeQuoteForm.tsx
@@ -39,7 +39,7 @@ const homeData = {
 const HomeQuoteForm = () => {
   const navigate = useNavigate();
   const [formState, setFormState] = useState({
-    // Información de la póliza de hogar - Persona principal
+    // Información de la póliza de hogar - tomador
     nombreCompleto: '',
     tipoDocumento: '',
     numeroDocumento: '',
@@ -207,7 +207,7 @@ const HomeQuoteForm = () => {
   const validateForm = () => {
     const newErrors = {};
     
-    // Validar información de la póliza de hogar - Persona principal
+    // Validar información de la póliza de hogar - tomador
     if (!formState.nombreCompleto) newErrors.nombreCompleto = 'El campo Nombre completo es requerido';
     if (!formState.tipoDocumento) newErrors.tipoDocumento = 'El campo Tipo de documento es requerido';
     if (!formState.numeroDocumento) newErrors.numeroDocumento = 'El campo Número documento es requerido';
@@ -322,9 +322,9 @@ const HomeQuoteForm = () => {
       
       <div className="bg-white rounded-lg shadow-md border border-gray-200 overflow-hidden mb-8">
         <div className="p-6 md:p-8">
-          {/* Póliza de hogar - Persona principal */}
+          {/* Póliza de hogar - tomador */}
           <FormSection 
-            title="COTIZAR PÓLIZA DE HOGAR - PERSONA PRINCIPAL" 
+            title="COTIZAR PÓLIZA DE HOGAR - TOMADOR" 
             icon={<User size={24} className="text-green-600" />}
           >
             <div className="space-y-6">

--- a/src/pages/LifeQuoteForm.tsx
+++ b/src/pages/LifeQuoteForm.tsx
@@ -39,7 +39,7 @@ const lifeData = {
 const LifeQuoteForm = () => {
   const navigate = useNavigate();
   const [formState, setFormState] = useState({
-    // Información de la póliza de vida - Persona principal
+    // Información de la póliza de vida - tomador
     nombreCompleto: '',
     tipoDocumento: '',
     numeroDocumento: '',
@@ -207,7 +207,7 @@ const LifeQuoteForm = () => {
   const validateForm = () => {
     const newErrors = {};
     
-    // Validar información de la póliza de vida - Persona principal
+    // Validar información de la póliza de vida - tomador
     if (!formState.nombreCompleto) newErrors.nombreCompleto = 'El campo Nombre completo es requerido';
     if (!formState.tipoDocumento) newErrors.tipoDocumento = 'El campo Tipo de documento es requerido';
     if (!formState.numeroDocumento) newErrors.numeroDocumento = 'El campo Número documento es requerido';
@@ -322,9 +322,9 @@ const LifeQuoteForm = () => {
       
       <div className="bg-white rounded-lg shadow-md border border-gray-200 overflow-hidden mb-8">
         <div className="p-6 md:p-8">
-          {/* Póliza de vida - Persona principal */}
+          {/* Póliza de vida - tomador */}
           <FormSection 
-            title="COTIZAR PÓLIZA DE VIDA - PERSONA PRINCIPAL" 
+            title="COTIZAR PÓLIZA DE VIDA - TOMADOR" 
             icon={<User size={24} className="text-blue-600" />}
           >
             <div className="space-y-6">
@@ -337,7 +337,16 @@ const LifeQuoteForm = () => {
                   required
                   error={errors.nombreCompleto}
                 />
-                
+
+                <FormInput
+                  label="Su correo electrónico"
+                  name="email"
+                  type="email"
+                  value={formState.email}
+                  onChange={handleInputChange}
+                  error={errors.email}
+                />
+
                 <FormSelect
                   label="Tipo de documento"
                   name="tipoDocumento"
@@ -347,7 +356,9 @@ const LifeQuoteForm = () => {
                   required
                   error={errors.tipoDocumento}
                 />
-                
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <FormInput
                   label="Número documento"
                   name="numeroDocumento"
@@ -356,9 +367,7 @@ const LifeQuoteForm = () => {
                   required
                   error={errors.numeroDocumento}
                 />
-              </div>
-              
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
                 <FormInput
                   label="Edad en años"
                   name="edad"
@@ -368,7 +377,7 @@ const LifeQuoteForm = () => {
                   required
                   error={errors.edad}
                 />
-                
+
                 <PhoneInput
                   label="Celular"
                   name="celular"
@@ -506,19 +515,11 @@ const LifeQuoteForm = () => {
             </FormSection>
           ))}
 
-          {/* Email adicional */}
-          <FormSection 
-            title="INFORMACIÓN ADICIONAL" 
+          {/* Información adicional */}
+          <FormSection
+            title="INFORMACIÓN ADICIONAL"
           >
             <div className="space-y-6">
-              <FormInput
-                label="Su correo electrónico"
-                name="email"
-                type="email"
-                value={formState.email}
-                onChange={handleInputChange}
-                error={errors.email}
-              />
               
               <div className="bg-blue-50 p-6 rounded-lg border border-blue-200">
                 <div className="flex items-start">

--- a/src/pages/PetQuoteForm.tsx
+++ b/src/pages/PetQuoteForm.tsx
@@ -39,7 +39,7 @@ const petData = {
 const PetQuoteForm = () => {
   const navigate = useNavigate();
   const [formState, setFormState] = useState({
-    // Información de la póliza de mascotas - Persona principal
+    // Información de la póliza de mascotas - tomador
     nombreCompleto: '',
     tipoDocumento: '',
     numeroDocumento: '',
@@ -207,7 +207,7 @@ const PetQuoteForm = () => {
   const validateForm = () => {
     const newErrors = {};
     
-    // Validar información de la póliza de mascotas - Persona principal
+    // Validar información de la póliza de mascotas - tomador
     if (!formState.nombreCompleto) newErrors.nombreCompleto = 'El campo Nombre completo es requerido';
     if (!formState.tipoDocumento) newErrors.tipoDocumento = 'El campo Tipo de documento es requerido';
     if (!formState.numeroDocumento) newErrors.numeroDocumento = 'El campo Número documento es requerido';
@@ -322,9 +322,9 @@ const PetQuoteForm = () => {
      
      <div className="bg-white rounded-lg shadow-md border border-gray-200 overflow-hidden mb-8">
        <div className="p-6 md:p-8">
-         {/* Póliza de mascotas - Persona principal */}
+         {/* Póliza de mascotas - tomador */}
          <FormSection 
-           title="COTIZAR PÓLIZA DE MASCOTAS - PERSONA PRINCIPAL" 
+           title="COTIZAR PÓLIZA DE MASCOTAS - TOMADOR" 
            icon={<User size={24} className="text-orange-600" />}
          >
            <div className="space-y-6">
@@ -337,7 +337,16 @@ const PetQuoteForm = () => {
                  required
                  error={errors.nombreCompleto}
                />
-               
+
+               <FormInput
+                 label="Su correo electrónico"
+                 name="email"
+                 type="email"
+                 value={formState.email}
+                 onChange={handleInputChange}
+                 error={errors.email}
+               />
+
                <FormSelect
                  label="Tipo de documento"
                  name="tipoDocumento"
@@ -347,7 +356,9 @@ const PetQuoteForm = () => {
                  required
                  error={errors.tipoDocumento}
                />
-               
+             </div>
+
+             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                <FormInput
                  label="Número documento"
                  name="numeroDocumento"
@@ -356,9 +367,7 @@ const PetQuoteForm = () => {
                  required
                  error={errors.numeroDocumento}
                />
-             </div>
-             
-             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
                <FormInput
                  label="Edad en años"
                  name="edad"
@@ -368,7 +377,7 @@ const PetQuoteForm = () => {
                  required
                  error={errors.edad}
                />
-               
+
                <PhoneInput
                  label="Celular"
                  name="celular"
@@ -506,19 +515,11 @@ const PetQuoteForm = () => {
            </FormSection>
          ))}
 
-         {/* Email adicional */}
-         <FormSection 
-           title="INFORMACIÓN ADICIONAL" 
+         {/* Información adicional */}
+         <FormSection
+           title="INFORMACIÓN ADICIONAL"
          >
            <div className="space-y-6">
-             <FormInput
-               label="Su correo electrónico"
-               name="email"
-               type="email"
-               value={formState.email}
-               onChange={handleInputChange}
-               error={errors.email}
-             />
              
              <div className="bg-orange-50 p-6 rounded-lg border border-orange-200">
                <div className="flex items-start">

--- a/src/pages/steps/PersonalInfoStep.tsx
+++ b/src/pages/steps/PersonalInfoStep.tsx
@@ -26,7 +26,19 @@ const PersonalInfoStep = ({
           required
           error={errors.ownerName}
         />
-        
+
+        <FormInput
+          label="Email"
+          name="email"
+          type="email"
+          icon={<Mail size={18} className="text-gray-500" />}
+          value={formState.email}
+          onChange={handleInputChange}
+          error={errors.email}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <FormInput
           label="Cédula"
           name="identification"
@@ -35,9 +47,7 @@ const PersonalInfoStep = ({
           required
           error={errors.identification}
         />
-      </div>
-      
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
         <FormInput
           label="Fecha de nacimiento"
           name="birthDate"
@@ -48,7 +58,9 @@ const PersonalInfoStep = ({
           required
           error={errors.birthDate}
         />
-        
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <FormInput
           label="Dirección"
           name="address"
@@ -58,9 +70,7 @@ const PersonalInfoStep = ({
           required
           error={errors.address}
         />
-      </div>
-      
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
         <PhoneInput
           label="Celular"
           name="phone"
@@ -69,16 +79,6 @@ const PersonalInfoStep = ({
           onChange={handlePhoneChange}
           required
           error={errors.phone}
-        />
-        
-        <FormInput
-          label="Email"
-          name="email"
-          type="email"
-          icon={<Mail size={18} className="text-gray-500" />}
-          value={formState.email}
-          onChange={handleInputChange}
-          error={errors.email}
         />
       </div>
     </FormSection>


### PR DESCRIPTION
## Summary
- reposition email field right after the name field across quote forms
- replace all references of "persona principal" with "tomador" to standardize terminology

## Testing
- `npm run lint` *(fails: `tailwind.config.ts` require import forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6876c5204d5c832192ea998b8d694006