### PR TITLE
Implement conditional life insurance form

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -2,7 +2,7 @@ interface FormData {
   name: string;
   email: string;
   company: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export const sendRegistrationEmails = async (formData: FormData) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -120,5 +121,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add option list for Seguro de Vida vs Plan Crédito Protegido
- include new life policy fields and motorcycle question
- sanitize numeric handling and validation
- send only relevant fields depending on insurance type
- display conditional insured values or credit fields
- update lint errors in shared UI components and config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876d0fad0b88321a3943fea3cfa0beb